### PR TITLE
Fix issue with viewing pages while logged out

### DIFF
--- a/app/views/question/show.erb
+++ b/app/views/question/show.erb
@@ -49,7 +49,7 @@
           <li class= "answer-gif"><img src="<%= answer.gif %>" /><span class="author-name"> - <%= answer.answerer.username %></span>
           <!-- best answer button -->
           <div class="best-answer-div" id=<%= answer.id %>>
-          <% if @question.author.id == current_user.id %>
+          <% if logged_in? && (@question.author.id == current_user.id) %>
             <button class="best-answer-button" type="button">Select Best Answer</button>
           <% end %>
           </div>


### PR DESCRIPTION
Added a quick little 'logged_in?' before 'current_user.id' to avoid issues with having logged-out users viewing a page